### PR TITLE
PBS Null Pointer Fix

### DIFF
--- a/src/main/java/com/admi/data/enums/statuses/PbsStatus.java
+++ b/src/main/java/com/admi/data/enums/statuses/PbsStatus.java
@@ -15,7 +15,7 @@ public enum PbsStatus implements DmsStatus {
 //	STK("Stock/Active", new String[]{"STK"}),
 	STOCK("Stock/Active",  new String[]{"STOCK", "STK", "S"}),
 	D("Delete", new String[]{"D"}),
-	C("Cores", new String[]{"C"}),
+	C("Cores", new String[]{"C", "CORE"}),
 	R("Replaced", new String[]{"R"}),
 	MANUAL_ORDER("Manual Order", new String[]{"MANUAL ORDER", "MANUAL_ORDER"}),
 	MEMO("Memo", new String[]{"MEMO"}),

--- a/src/main/java/com/admi/data/services/StatusService.java
+++ b/src/main/java/com/admi/data/services/StatusService.java
@@ -232,6 +232,8 @@ public class StatusService {
             case 30:
                 try {
                     status = PbsStatus.findStatus(statusString); //case-insensitive
+                    if(status == null)
+                        status = PbsStatus.TEST;
                 } catch (NullPointerException | IllegalArgumentException e) {
                     status = PbsStatus.TEST;
                 }


### PR DESCRIPTION
Added in a null check for if we don't recognize a certain PBS status, since we didn't recognize the latest data's status of "Core". I assumed this corresponds to the "C" status; feel free to correct.